### PR TITLE
docs(typo): changing Github to GitHub

### DIFF
--- a/docs/lib/Home/index.js
+++ b/docs/lib/Home/index.js
@@ -21,7 +21,7 @@ export default () => {
                 Easy to use form validation for <a href="https://github.com/reactstrap/reactstrap">reactstrap</a>
               </p>
               <p>
-                <Button outline color="danger" href="https://github.com/availity/availity-reactstrap-validation">View on Github</Button>
+                <Button outline color="danger" href="https://github.com/availity/availity-reactstrap-validation">View on GitHub</Button>
                 <Button color="danger" tag={Link} to="/components/">View Components</Button>
               </p>
             </Col>

--- a/docs/lib/UI/Nav.js
+++ b/docs/lib/UI/Nav.js
@@ -48,7 +48,7 @@ export default class UINav extends Component {
               </NavItem>
               <NavItem>
                 <NavLink href="https://github.com/availity/availity-reactstrap-validation">
-                  Github
+                  GitHub
                 </NavLink>
               </NavItem>
             </Nav>


### PR DESCRIPTION
Fix GitHub typo in navbar link and home page button.