### PR TITLE
feat(AvInput): support multiple tags

### DIFF
--- a/src/AvField.js
+++ b/src/AvField.js
@@ -101,7 +101,11 @@ export default class AvField extends Component {
     const inputRow = row ? <Col {...col}>{input}{feedback}{help}</Col> : input;
     const check = attributes.type === 'checkbox';
 
-    if ((check || attributes.type === 'radio') && attributes.tag === CustomInput) {
+    if (
+      (check || attributes.type === "radio") &&
+      (attributes.tag === CustomInput ||
+        (Array.isArray(attributes.tag) && attributes.tag[0] === CustomInput))
+    ) {
       return <AvGroup className="mb-0"><AvInput {...this.props}>{feedback}{help}</AvInput></AvGroup>;
     }
 

--- a/src/AvInput.js
+++ b/src/AvInput.js
@@ -30,7 +30,7 @@ export default class AvInput extends AvBaseInput {
       valueParser: omit7,
       valueFormatter: omit8,
       className,
-      tag: Tag,
+      tag,
       getRef,
       id = this.props.name,
       ...attributes
@@ -38,6 +38,15 @@ export default class AvInput extends AvBaseInput {
 
     const touched = this.context.FormCtrl.isTouched(this.props.name);
     const hasError = this.context.FormCtrl.hasError(this.props.name);
+    let Tag = tag;
+
+    if (Array.isArray(tag)) {
+      [Tag, ...tags] = tag;
+      attributes.tag = tags
+      if(attributes.tag.length <= 1) {
+        attributes.tag = attributes.tag[0];
+      }
+    }
 
     const classes = classNames(
       className,


### PR DESCRIPTION
fixes #107 

This allows `tag` to be an array of tags to allow for composing multiple components.
If `tag` is an array, `AvInput` will take the first item in the array and use that as its tag. It will pass the remaining items to the next component (the first tag). Additional, if only 1 item is left in the array (such as when passing an array of 2 tags to `AvInput`) it will unwrap the tag out of the array.