### PR TITLE
fix(AvInput): define tags

### DIFF
--- a/src/AvInput.js
+++ b/src/AvInput.js
@@ -41,6 +41,7 @@ export default class AvInput extends AvBaseInput {
     let Tag = tag;
 
     if (Array.isArray(tag)) {
+      let tags;
       [Tag, ...tags] = tag;
       attributes.tag = tags
       if(attributes.tag.length <= 1) {


### PR DESCRIPTION
Fixes `tags` not being defined and causing a 💥 when `tag` is an array.

See: https://github.com/Availity/availity-reactstrap-validation/pull/110#pullrequestreview-188253980