### PR TITLE
fix: checkbox default value was not being accepted properly

### DIFF
--- a/src/AvCheckbox.js
+++ b/src/AvCheckbox.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import find from 'lodash/find';
 import {Input, FormGroup, Label, CustomInput} from 'reactstrap';
 import AvInput from './AvInput';
 
@@ -31,7 +32,7 @@ export default class AvCheckbox extends Component {
   };
 
   isDefaultChecked(valueArr) {
-    return Array.isArray(valueArr) && valueArr.length > 0 && valueArr.filter(item => item === this.props.value);
+    return Array.isArray(valueArr) && valueArr.length > 0 && find(valueArr,item => item === this.props.value);
   }
 
   render() {


### PR DESCRIPTION
When using the model prop on the AvForm, you should be able to pass in an array of names for the components you want to be checked by default in the AvCheckboxGroup. However, the valueArr in this case when using the filter method returns an array of size 0. Instead we can just use the lodash/find property to make sure that if the item is not found that it returns null.

Also should the below line not be using `this.props.name` and not the actual value prop passed into the checkbox?
https://github.com/Availity/availity-reactstrap-validation/blob/a0f73b710a1a5063cf2877b6f6ff807b53004719/src/AvCheckbox.js#L33-L35