### PR TITLE
fix: fix step validator for exponent

### DIFF
--- a/__test__/AvValidator.step.spec.js
+++ b/__test__/AvValidator.step.spec.js
@@ -34,15 +34,21 @@ describe('Step Validation', () => {
     expect(fn(11.5, undefined, {value: 5.3})).to.be.false;
     expect(fn(10.5, undefined, {value: 6.7})).to.be.false;
     expect(fn(10.5, undefined, {value: 2.1})).to.be.true;
+    expect(fn(0.00000002, undefined, {value: 0.00000001})).to.be.true;
+    expect(fn(0.000000011, undefined, {value: 0.00000001})).to.be.false;
 
     expect(fn('10.2', undefined, {value: 5.1})).to.be.true;
     expect(fn('11.5', undefined, {value: 5.55})).to.be.false;
     expect(fn('10.55', undefined, {value: 6.2})).to.be.false;
     expect(fn('10.5', undefined, {value: 2.1})).to.be.true;
+    expect(fn('0.00000002', undefined, {value: 0.00000001})).to.be.true;
+    expect(fn('0.000000011', undefined, {value: 0.00000001})).to.be.false;
 
     expect(fn(10.2, undefined, {value: '5.1'})).to.be.true;
     expect(fn(11.5, undefined, {value: '5.4'})).to.be.false;
     expect(fn(10.5, undefined, {value: '6.7'})).to.be.false;
     expect(fn(10.5, undefined, {value: '2.1'})).to.be.true;
+    expect(fn(0.00000002, undefined, {value: '0.00000001'})).to.be.true;
+    expect(fn(0.000000011, undefined, {value: '0.00000001'})).to.be.false;
   });
 });

--- a/src/AvValidator/step.js
+++ b/src/AvValidator/step.js
@@ -1,10 +1,19 @@
 import toNumber from 'lodash/toNumber';
 import { isEmpty } from './utils';
 
+function getDecCount(val) {
+  const valStr = val.toString();
+  if (valStr.indexOf('e-') > -1) {
+    const valArr = valStr.split('e-');
+    return parseInt((valArr[0].split('.')[1] || '').length, 10) + parseInt(valArr[1], 10);
+  }
+  return (valStr.split('.')[1] || '').length;
+}
+
 // http://stackoverflow.com/a/31711034/1873485
 function floatSafeRemainder(val, step) {
-  const valDecCount = (val.toString().split('.')[1] || '').length;
-  const stepDecCount = (step.toString().split('.')[1] || '').length;
+  const valDecCount = getDecCount(val);
+  const stepDecCount = getDecCount(step);
   const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
   const valInt = parseInt(val.toFixed(decCount).replace('.', ''), 10);
   const stepInt = parseInt(step.toFixed(decCount).replace('.', ''), 10);


### PR DESCRIPTION
ex)
<AvField name="step5" label="Step" type="number" step="0.00000001" />
for numbers like 0.00000001 it's 1e-8 which doesn't includes dot.
so it can't be validated.