### PR TITLE
refactor: updated form to not update submitted state if its unmounting

### DIFF
--- a/src/AvForm.js
+++ b/src/AvForm.js
@@ -19,6 +19,8 @@ const getInputErrorMessage = (input, ruleName) => {
 };
 
 export default class AvForm extends InputContainer {
+  _isMounted = false;
+
   static childContextTypes = {
     FormCtrl: PropTypes.object.isRequired,
   };
@@ -109,7 +111,7 @@ export default class AvForm extends InputContainer {
       this.props.onInvalidSubmit(e, errors, values);
     }
 
-    !this.state.submitted && this.setState({submitted: true});
+    !this.state.submitted && this._isMounted && this.setState({submitted: true});
   };
 
   handleNonFormSubmission = (event) => {
@@ -148,7 +150,12 @@ export default class AvForm extends InputContainer {
     };
   }
 
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
   componentWillMount() {
+    this._isMounted = true;
     super.componentWillMount();
 
     this._validators = {};


### PR DESCRIPTION
In a lot of cases we are seeing developers just not display the form after the `onValidSubmit` callback has been fired and in this case `react` will warn about state updates occuring after unmounting since the `submitted` state gets updated after the callbacks have been fired.