### PR TITLE
Fix checkbox defaultChecked state interpreted as not provided

### DIFF
--- a/src/AvCheckbox.js
+++ b/src/AvCheckbox.js
@@ -32,7 +32,7 @@ export default class AvCheckbox extends Component {
   };
 
   isDefaultChecked(valueArr) {
-    return Array.isArray(valueArr) && valueArr.length > 0 && find(valueArr,item => item === this.props.value);
+    return Array.isArray(valueArr) && valueArr.length > 0 && !!find(valueArr,item => item === this.props.value);
   }
 
   render() {


### PR DESCRIPTION
AvCheckbox with default values was not correctly treating defaultChecked propertie, because a undefined value is treated as not provided, so the checkbocks is marked as checked even than the value is not present on array.

Reference:
https://stackoverflow.com/questions/55259173/react-handling-multiple-checkboxes

So just adding a corrent treating for undefined return of `find` call solved the problem.