### PR TITLE
include reactstrap in installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Easy to use React validation components compatible for reactstrap.
 
 ## Installation
 
-Install `availity-reactstrap-validation` via NPM
+Install `availity-reactstrap-validation` and `reactstrap` via NPM
 
 ```sh
-npm install --save availity-reactstrap-validation
+npm install --save availity-reactstrap-validation reactstrap
 ```
 
 If applicable, install a `Promise` polyfill.  For example:


### PR DESCRIPTION
current reactstrap is a peerDependency, but it is not included in the installation steps.
This adds it to the installation step.