### PR TITLE
feat: add getInputs helper method to FormCtrl

### DIFF
--- a/__test__/AvForm.spec.js
+++ b/__test__/AvForm.spec.js
@@ -374,6 +374,30 @@ describe('AvForm', function () {
       });
     });
 
+    describe('get Inputs', () => {
+      it('should return an object', () => {
+        expect(this.instance.getInputs()).to.be.an('object');
+      });
+
+      it('should return the registered inputs', () => {
+        const name = 'nameValue';
+        const email = 'evan.sharp@availity.com';
+        const dateOfBirth = new Date();
+        const number = 4;
+        this.instance._inputs = {
+          name: { getValue: sinon.stub().returns(name) },
+          email: { getValue: sinon.stub().returns(email) },
+          dateOfBirth: { getValue: sinon.stub().returns(dateOfBirth) },
+          number: { getValue: sinon.stub().returns(number) },
+        };
+
+        const inputs = this.instance.getInputs();
+
+        expect(Object.keys(inputs).length).to.equal(4);
+        expect(inputs).to.have.all.keys('name', 'email', 'dateOfBirth', 'number');
+      });
+    });
+
     describe('get Values', () => {
       it('should return an object', () => {
         expect(this.instance.getValues()).to.be.an('object');

--- a/src/AvBaseInput.js
+++ b/src/AvBaseInput.js
@@ -21,7 +21,7 @@ const htmlValidationTypes = [
   'number',
   'tel',
   'url',
-  /*'range', 'month', 'week', 'time'*/ // These do not currently have validation
+  /* 'range', 'month', 'week', 'time'*/ // These do not currently have validation
 ];
 
 export default class AvBaseInput extends Component {

--- a/src/AvCheckbox.js
+++ b/src/AvCheckbox.js
@@ -32,7 +32,7 @@ export default class AvCheckbox extends Component {
   };
 
   isDefaultChecked(valueArr) {
-    return Array.isArray(valueArr) && valueArr.length > 0 && find(valueArr,item => item === this.props.value);
+    return Array.isArray(valueArr) && valueArr.length > 0 && find(valueArr, item => item === this.props.value);
   }
 
   render() {

--- a/src/AvCheckboxGroup.js
+++ b/src/AvCheckboxGroup.js
@@ -42,7 +42,7 @@ export default class AvCheckboxGroup extends Component {
       this.FormCtrl.validate = noop;
     }
 
-    const updateGroup = async (e, value) => {
+    const updateGroup = async(e, value) => {
       if (e.target.checked) {
         this.value.push(value);
       } else {
@@ -223,7 +223,7 @@ export default class AvCheckboxGroup extends Component {
       <FormGroup tag="fieldset" {...attributes} className={groupClass}>
         {legend}
         <div className={classes}>{children}</div>
-       <AvFeedback>{validation.errorMessage}</AvFeedback>
+        <AvFeedback>{validation.errorMessage}</AvFeedback>
       </FormGroup>
     );
   }

--- a/src/AvField.js
+++ b/src/AvField.js
@@ -102,7 +102,7 @@ export default class AvField extends Component {
     const check = attributes.type === 'checkbox';
 
     if (
-      (check || attributes.type === "radio" || attributes.type === "switch") &&
+      (check || attributes.type === 'radio' || attributes.type === 'switch') &&
       (attributes.tag === CustomInput ||
         (Array.isArray(attributes.tag) && attributes.tag[0] === CustomInput))
     ) {

--- a/src/AvForm.js
+++ b/src/AvForm.js
@@ -83,7 +83,7 @@ export default class AvForm extends InputContainer {
 
   validations = {};
 
-  handleSubmit = async (e) => {
+  handleSubmit = async(e) => {
     if (this.props.beforeSubmitValidation) {
       this.props.beforeSubmitValidation(e);
     }
@@ -131,6 +131,7 @@ export default class AvForm extends InputContainer {
         getInputState: this.getInputState.bind(this),
         getInput: name => this._inputs[name],
         getInputValue: this.getValue.bind(this),
+        getInputs: this.getInputs.bind(this),
         getValues: this.getValues.bind(this),
         hasError: this.hasError.bind(this),
         isDirty: this.isDirty.bind(this),
@@ -215,6 +216,10 @@ export default class AvForm extends InputContainer {
         onSubmit={this.handleSubmit}
       />
     );
+  }
+
+  getInputs() {
+    return this._inputs;
   }
 
   getValues() {
@@ -446,7 +451,7 @@ export default class AvForm extends InputContainer {
   }
 
   compileValidationRules(input, ruleProp) {
-    return async (val, context) => {
+    return async(val, context) => {
       if (this.isBad(input.props.name)) {
         return false;
       }

--- a/src/AvInput.js
+++ b/src/AvInput.js
@@ -42,9 +42,10 @@ export default class AvInput extends AvBaseInput {
 
     if (Array.isArray(tag)) {
       let tags;
+      // eslint-disable-next-line prefer-const
       [Tag, ...tags] = tag;
-      attributes.tag = tags
-      if(attributes.tag.length <= 1) {
+      attributes.tag = tags;
+      if (attributes.tag.length <= 1) {
         attributes.tag = attributes.tag[0];
       }
     }

--- a/src/AvRadioGroup.js
+++ b/src/AvRadioGroup.js
@@ -41,7 +41,7 @@ export default class AvRadioGroup extends Component {
       this.FormCtrl.validate = noop;
     }
 
-    const updateGroup = async (e, value) => {
+    const updateGroup = async(e, value) => {
       this.setState({ value });
       this.value = value;
       await this.validate();


### PR DESCRIPTION
Makes `_inputs` from `FormCtrl` accessible via a method called `getInputs()`, which can be useful for certain use cases.

This PR also corrects some linter errors