### PR TITLE
Error message during npm install availity-reactstrap-validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "Form validation helpers for reactstrap",
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 5.0.0",
-    "npm": "^3.0.0"
+    "node": ">= 5.0.0"
   },
   "scripts": {
     "ci": "npm run lint && cross-env BABEL_ENV=test nyc mocha-webpack",


### PR DESCRIPTION
When you run this command:
```
npm install --save availity-reactstrap-validation reactstrap
```
An error message appears:
`npm WARN notsup Unsupported engine for availity-reactstrap-validation@2.7.0: wanted: {"node":">= 5.0.0","npm":"^3.0.0"} (current: {"node":"14.15.1","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: availity-reactstrap-validation@2.7.0`

![image](https://user-images.githubusercontent.com/9989211/107119887-b4060100-688a-11eb-943e-061fa6663907.png)
